### PR TITLE
Use truststore_password in server.xml template

### DIFF
--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -108,7 +108,7 @@
                keystoreFile="<%= @config_dir %>/<%= @keystore_file %>"
                keystorePass="<%= node['tomcat']['keystore_password'] %>"
                keystoreType="<%= @keystore_type %>"
-               truststorePass="<%= node['tomcat']['keystore_password'] %>"
+               truststorePass="<%= node['tomcat']['truststore_password'] %>"
                maxThreads="<%= @ssl_max_threads %>" scheme="https" secure="true"
                clientAuth="false" sslProtocol="TLS" />
   <% end -%>


### PR DESCRIPTION
Current template uses ```keystore_password``` in both instances.