### PR TITLE
Make package names attribute driven

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,9 @@
 
 default['tomcat']['base_version'] = 6
 default['tomcat']['package_name'] = "tomcat#{node['tomcat']['base_version']}"
-default['tomcat']['manager_package_name'] = "tomcat#{node['tomcat']['base_version']}-admin-webapps"
+default['tomcat']['manager_package_name'] = "#{node['tomcat']['package_name']}-admin-webapps"
+default['tomcat']['install_name'] = node['tomcat']['package_name']
+default['tomcat']['manager_install_name'] = node['tomcat']['manager_package_name']
 default['tomcat']['version'] = nil
 default['tomcat']['port'] = 8080
 default['tomcat']['proxy_port'] = nil
@@ -57,29 +59,29 @@ case node['platform']
 when 'centos', 'redhat', 'fedora', 'amazon', 'scientific', 'oracle'
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}/temp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}/work"
+  default['tomcat']['home'] = "/usr/share/#{node['tomcat']['install_name']}"
+  default['tomcat']['base'] = "/usr/share/#{node['tomcat']['install_name']}"
+  default['tomcat']['config_dir'] = "/etc/#{node['tomcat']['install_name']}"
+  default['tomcat']['log_dir'] = "/var/log/#{node['tomcat']['install_name']}"
+  default['tomcat']['tmp_dir'] = "/var/cache/#{node['tomcat']['install_name']}/temp"
+  default['tomcat']['work_dir'] = "/var/cache/#{node['tomcat']['install_name']}/work"
   default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['webapp_dir'] = "/var/lib/#{node['tomcat']['install_name']}/webapps"
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
 when 'debian', 'ubuntu'
-  default['tomcat']['manager_package_name'] = "tomcat#{node['tomcat']['base_version']}-admin"
+  default['tomcat']['manager_package_name'] = "#{node['tomcat']['package_name']}-admin"
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
+  default['tomcat']['home'] = "/usr/share/#{node['tomcat']['install_name']}"
+  default['tomcat']['base'] = "/var/lib/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['config_dir'] = "/etc/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['log_dir'] = "/var/log/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['tmp_dir'] = "/tmp/#{node["tomcat"]["install_name"]}-tmp"
+  default['tomcat']['work_dir'] = "/var/cache/#{node["tomcat"]["install_name"]}"
   default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['webapp_dir'] = "/var/lib/#{node["tomcat"]["install_name"]}/webapps"
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
@@ -102,14 +104,14 @@ when 'smartos'
 else
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
+  default['tomcat']['home'] = "/usr/share/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['base'] = "/var/lib/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['config_dir'] = "/etc/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['log_dir'] = "/var/log/#{node["tomcat"]["install_name"]}"
+  default['tomcat']['tmp_dir'] = "/tmp/#{node["tomcat"]["install_name"]}-tmp"
+  default['tomcat']['work_dir'] = "/var/cache/#{node["tomcat"]["install_name"]}"
   default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['webapp_dir'] = "/var/lib/#{node["tomcat"]["install_name"]}/webapps"
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,7 +85,7 @@ when 'debian', 'ubuntu'
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
 when 'smartos'
   default['tomcat']['package_name'] = 'apache-tomcat'
-  default['tomcat']['version'] = node['tomcat']['base_version']
+  default['tomcat']['version'] = "#{node['tomcat']['base_version']}"
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
   default['tomcat']['home'] = '/opt/local/share/tomcat'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 
 default['tomcat']['base_version'] = 6
+default['tomcat']['package_name'] = "tomcat#{node['tomcat']['base_version']}"
+default['tomcat']['manager_package_name'] = "tomcat#{node['tomcat']['base_version']}-admin-webapps"
+default['tomcat']['version'] = nil
 default['tomcat']['port'] = 8080
 default['tomcat']['proxy_port'] = nil
 default['tomcat']['ssl_port'] = 8443
@@ -47,6 +50,7 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
+  
 
 case node['platform']
 
@@ -65,6 +69,7 @@ when 'centos', 'redhat', 'fedora', 'amazon', 'scientific', 'oracle'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
 when 'debian', 'ubuntu'
+  default['tomcat']['manager_package_name'] = "tomcat#{node['tomcat']['base_version']}-admin"
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
@@ -79,6 +84,8 @@ when 'debian', 'ubuntu'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
 when 'smartos'
+  default['tomcat']['package_name'] = 'apache-tomcat'
+  default['tomcat']['version'] = node['tomcat']['base_version']
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
   default['tomcat']['home'] = '/opt/local/share/tomcat'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license          'Apache 2.0'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.16.2'
+version          '0.16.3'
 
 depends 'java'
 depends 'openssl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license          'Apache 2.0'
 description      'Installs/Configures tomcat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.16.3'
+version          '0.16.2'
 
 depends 'java'
 depends 'openssl'

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -1,5 +1,5 @@
 action :configure do
-  base_instance = node['tomcat']['package_name']
+  base_instance = node['tomcat']['install_name']
 
   # Set defaults for resource attributes from node attributes. We can't do
   # this in the resource declaration because node isn't populated yet when
@@ -33,7 +33,7 @@ action :configure do
     [:base, :home, :config_dir, :log_dir, :work_dir, :context_dir,
      :webapp_dir].each do |attr|
       if not new_resource.instance_variable_get("@#{attr}") and node["tomcat"][attr]
-        new = node["tomcat"][attr].sub("tomcat#{node['tomcat']['base_version']}", "#{instance}")
+        new = node["tomcat"][attr].sub(node['tomcat']['install_name'], "#{instance}")
         new_resource.instance_variable_set("@#{attr}", new)
       end
     end

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -154,6 +154,7 @@ action :configure do
     end
   end
 
+  Chef::Log.info "Creating template resource : #{new_resource.config_dir}/server.xml"
   template "#{new_resource.config_dir}/server.xml" do
     source 'server.xml.erb'
       variables ({

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -154,7 +154,6 @@ action :configure do
     end
   end
 
-  Chef::Log.info "Creating template resource : #{new_resource.config_dir}/server.xml"
   template "#{new_resource.config_dir}/server.xml" do
     source 'server.xml.erb'
       variables ({

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -1,5 +1,5 @@
 action :configure do
-  base_instance = "tomcat#{node['tomcat']['base_version']}"
+  base_instance = node['tomcat']['package_name']
 
   # Set defaults for resource attributes from node attributes. We can't do
   # this in the resource declaration because node isn't populated yet when

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,29 +22,15 @@
 
 include_recipe 'java'
 
-tomcat_pkgs = value_for_platform(
-  ['smartos'] => {
-    'default' => ['apache-tomcat'],
-  },
-  'default' => ["tomcat#{node['tomcat']['base_version']}"]
-  )
+tomcat_pkgs = [node['tomcat']['package_name']]
 if node['tomcat']['deploy_manager_apps']
-  tomcat_pkgs << value_for_platform(
-    %w{ debian  ubuntu } => {
-      'default' => "tomcat#{node['tomcat']['base_version']}-admin",
-    },    
-    %w{ centos redhat fedora amazon scientific oracle } => {
-      'default' => "tomcat#{node['tomcat']['base_version']}-admin-webapps",
-    }
-    )
+  tomcat_pkgs << node['tomcat']['manager_package_name']
 end
-
-tomcat_pkgs.compact!
 
 tomcat_pkgs.each do |pkg|
   package pkg do
     action :install
-    version node['tomcat']['base_version'].to_s if platform_family?('smartos')
+    version node['tomcat']['version'].to_s if node['tomcat']['version']
   end
 end
 


### PR DESCRIPTION
We use CentOS 6.5, and the tomcat 7 package in EPEL is just 'tomcat' not 'tomcat7'. It installs everything in 'tomcat' directories. This update will allow you to define the name of your tomcat package as well as the name of the various installation directories.