### PR TITLE
Fix package names and directories for Tomcat 7 on RHEL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,12 +22,15 @@ platforms:
 
 - name: centos-6.5
 
+- name: centos-7.0
+
 suites:
 - name: tomcat6
   run_list: ["recipe[tomcat]"]
+  excludes: ["centos-7.0"]
   attributes: {}
 
 - name: tomcat7
   run_list: ["recipe[tomcat]"]
-  excludes: ["ubuntu-10.04", "centos-6.5"]
+  excludes: ["ubuntu-10.04"]
   attributes: {tomcat: {base_version: 7}}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 default['tomcat']['base_version'] = 6
+default['tomcat']['base_instance'] = "tomcat#{node['tomcat']['base_version']}"
 default['tomcat']['port'] = 8080
 default['tomcat']['proxy_port'] = nil
 default['tomcat']['ssl_port'] = 8443
@@ -47,24 +48,31 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
+default['tomcat']['packages'] = ["tomcat#{node['tomcat']['base_version']}"]
+default['tomcat']['deploy_manager_packages'] = ["tomcat#{node['tomcat']['base_version']}-admin"]
 
-case node['platform']
+case node['platform_family']
 
-when 'centos', 'redhat', 'fedora', 'amazon', 'scientific', 'oracle'
+when 'rhel', 'fedora'
+  suffix = node['tomcat']['base_version'].to_i < 7 ? node['tomcat']['base_version'] : ""
+
+  default['tomcat']['base_instance'] = "tomcat#{suffix}"
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}/temp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}/work"
+  default['tomcat']['home'] = "/usr/share/tomcat#{suffix}"
+  default['tomcat']['base'] = "/usr/share/tomcat#{suffix}"
+  default['tomcat']['config_dir'] = "/etc/tomcat#{suffix}"
+  default['tomcat']['log_dir'] = "/var/log/tomcat#{suffix}"
+  default['tomcat']['tmp_dir'] = "/var/cache/tomcat#{suffix}/temp"
+  default['tomcat']['work_dir'] = "/var/cache/tomcat#{suffix}/work"
   default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{suffix}/webapps"
   default['tomcat']['keytool'] = 'keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
-when 'debian', 'ubuntu'
+  default['tomcat']['packages'] = ["tomcat#{suffix}"]
+  default['tomcat']['deploy_manager_packages'] = ["tomcat#{suffix}-admin-webapps"]
+when 'debian'
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
@@ -92,6 +100,8 @@ when 'smartos'
   default['tomcat']['keytool'] = '/opt/local/bin/keytool'
   default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
   default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["home"]}/lib/endorsed"
+  default['tomcat']['packages'] = ["apache-tomcat"]
+  default['tomcat']['deploy_manager_packages'] = []
 else
   default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
   default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version          '0.16.2'
 
 depends 'java'
 depends 'openssl'
+depends 'yum-epel'
 
 supports 'debian'
 supports 'ubuntu'

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -1,5 +1,5 @@
 action :configure do
-  base_instance = "tomcat#{node['tomcat']['base_version']}"
+  base_instance = node['tomcat']['base_instance']
 
   # Set defaults for resource attributes from node attributes. We can't do
   # this in the resource declaration because node isn't populated yet when
@@ -33,7 +33,7 @@ action :configure do
     [:base, :home, :config_dir, :log_dir, :work_dir, :context_dir,
      :webapp_dir].each do |attr|
       if not new_resource.instance_variable_get("@#{attr}") and node["tomcat"][attr]
-        new = node["tomcat"][attr].sub("tomcat#{node['tomcat']['base_version']}", "#{instance}")
+        new = node["tomcat"][attr].sub(base_instance, instance)
         new_resource.instance_variable_set("@#{attr}", new)
       end
     end
@@ -118,8 +118,8 @@ action :configure do
     new_resource.java_options = java_options
   end
 
-  case node['platform']
-  when 'centos', 'redhat', 'fedora', 'amazon', 'oracle'
+  case node['platform_family']
+  when 'rhel', 'fedora'
     template "/etc/sysconfig/#{instance}" do
       source 'sysconfig_tomcat6.erb'
       variables ({
@@ -257,11 +257,11 @@ action :configure do
   end
 
   service "#{instance}" do
-    case node['platform']
-    when 'centos', 'redhat', 'fedora', 'amazon'
+    case node['platform_family']
+    when 'rhel', 'fedora'
       service_name "#{instance}"
       supports :restart => true, :status => true
-    when 'debian', 'ubuntu'
+    when 'debian'
       service_name "#{instance}"
       supports :restart => true, :reload => false, :status => true
     when 'smartos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,29 +22,21 @@
 
 include_recipe 'java'
 
-tomcat_pkgs = value_for_platform(
-  ['smartos'] => {
-    'default' => ['apache-tomcat'],
-  },
-  'default' => ["tomcat#{node['tomcat']['base_version']}"]
-  )
-if node['tomcat']['deploy_manager_apps']
-  tomcat_pkgs << value_for_platform(
-    %w{ debian  ubuntu } => {
-      'default' => "tomcat#{node['tomcat']['base_version']}-admin",
-    },    
-    %w{ centos redhat fedora amazon scientific oracle } => {
-      'default' => "tomcat#{node['tomcat']['base_version']}-admin-webapps",
-    }
-    )
+if node['tomcat']['base_version'].to_i == 7
+  if platform_family?('rhel') and node[:platform_version].to_i < 7
+    include_recipe 'yum-epel'
+  end
 end
 
-tomcat_pkgs.compact!
-
-tomcat_pkgs.each do |pkg|
+node['tomcat']['packages'].each do |pkg|
   package pkg do
     action :install
-    version node['tomcat']['base_version'].to_s if platform_family?('smartos')
+  end
+end
+
+node['tomcat']['deploy_manager_packages'].each do |pkg|
+  package pkg do
+    action :install
   end
 end
 

--- a/templates/default/tomcat.service.erb
+++ b/templates/default/tomcat.service.erb
@@ -1,0 +1,17 @@
+# Systemd unit file for <%= @instance %>
+
+[Unit]
+Description=<%= @instance %> Apache Tomcat Application
+After=syslog.target network.target
+
+[Service]
+Type=forking
+Environment="SERVICE_NAME=<%= @instance %>"
+ExecStart=/usr/sbin/tomcat-sysd start
+ExecStop=/usr/sbin/tomcat-sysd stop
+SuccessExitStatus=143
+User=<%= @user %>
+Group=<%= @group %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* This builds on my colleague's earlier work of adding systemd support in #115 so merge that first.
* It closes #74. It was inspired by @joerocklin's work but I pretty much did my own thing in the end, particularly with regard to where the attributes are set.
* Using platform_family simplified some of the logic and this should close #47.
* It also closes #96, which only deals with CentOS 6 and not 7.
* The attributes could use some refactoring but that should be dealt with separately.