### PR TITLE
Added lazy block to all calculated attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 default['tomcat']['base_version'] = 6
-default['tomcat']['base_instance'] = "tomcat#{node['tomcat']['base_version']}"
+default['tomcat']['base_instance'] = lazy {"tomcat#{node['tomcat']['base_version']}"}
 default['tomcat']['port'] = 8080
 default['tomcat']['proxy_port'] = nil
 default['tomcat']['ssl_port'] = 8443
@@ -48,44 +48,44 @@ default['tomcat']['loglevel'] = 'INFO'
 default['tomcat']['tomcat_auth'] = 'true'
 default['tomcat']['instances'] = {}
 default['tomcat']['run_base_instance'] = true
-default['tomcat']['packages'] = ["tomcat#{node['tomcat']['base_version']}"]
-default['tomcat']['deploy_manager_packages'] = ["tomcat#{node['tomcat']['base_version']}-admin"]
+default['tomcat']['packages'] = lazy {["tomcat#{node['tomcat']['base_version']}"]}
+default['tomcat']['deploy_manager_packages'] = lazy{["tomcat#{node['tomcat']['base_version']}-admin"]}
 
 case node['platform_family']
 
 when 'rhel', 'fedora'
-  suffix = node['tomcat']['base_version'].to_i < 7 ? node['tomcat']['base_version'] : ""
+  suffix = lazy {node['tomcat']['base_version'].to_i < 7 ? node['tomcat']['base_version'] : ""}
 
-  default['tomcat']['base_instance'] = "tomcat#{suffix}"
+  default['tomcat']['base_instance'] = lazy{"tomcat#{suffix}"}
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
-  default['tomcat']['home'] = "/usr/share/tomcat#{suffix}"
-  default['tomcat']['base'] = "/usr/share/tomcat#{suffix}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{suffix}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{suffix}"
-  default['tomcat']['tmp_dir'] = "/var/cache/tomcat#{suffix}/temp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{suffix}/work"
-  default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{suffix}/webapps"
+  default['tomcat']['home'] = lazy {"/usr/share/tomcat#{suffix}"}
+  default['tomcat']['base'] = lazy {"/usr/share/tomcat#{suffix}"}
+  default['tomcat']['config_dir'] = lazy {"/etc/tomcat#{suffix}"}
+  default['tomcat']['log_dir'] = lazy {"/var/log/tomcat#{suffix}"}
+  default['tomcat']['tmp_dir'] = lazy {"/var/cache/tomcat#{suffix}/temp"}
+  default['tomcat']['work_dir'] = lazy {"/var/cache/tomcat#{suffix}/work"}
+  default['tomcat']['context_dir'] = lazy {"#{node["tomcat"]["config_dir"]}/Catalina/localhost"}
+  default['tomcat']['webapp_dir'] = lazy {"/var/lib/tomcat#{suffix}/webapps"}
   default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
-  default['tomcat']['packages'] = ["tomcat#{suffix}"]
-  default['tomcat']['deploy_manager_packages'] = ["tomcat#{suffix}-admin-webapps"]
+  default['tomcat']['lib_dir'] = lazy {"#{node["tomcat"]["home"]}/lib"}
+  default['tomcat']['endorsed_dir'] = lazy {"#{node["tomcat"]["lib_dir"]}/endorsed"}
+  default['tomcat']['packages'] = lazy {["tomcat#{suffix}"]}
+  default['tomcat']['deploy_manager_packages'] = lazy {["tomcat#{suffix}-admin-webapps"]}
 when 'debian'
-  default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['user'] = lazy {"tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['group'] = lazy {"tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['home'] = lazy {"/usr/share/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['base'] = lazy {"/var/lib/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['config_dir'] = lazy {"/etc/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['log_dir'] = lazy {"/var/log/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['tmp_dir'] = lazy {"/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"}
+  default['tomcat']['work_dir'] = lazy {"/var/cache/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['context_dir'] = lazy {"#{node["tomcat"]["config_dir"]}/Catalina/localhost"}
+  default['tomcat']['webapp_dir'] = lazy {"/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"}
   default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
+  default['tomcat']['lib_dir'] = lazy {"#{node["tomcat"]["home"]}/lib"}
+  default['tomcat']['endorsed_dir'] = lazy {"#{node["tomcat"]["lib_dir"]}/endorsed"}
 when 'smartos'
   default['tomcat']['user'] = 'tomcat'
   default['tomcat']['group'] = 'tomcat'
@@ -95,25 +95,25 @@ when 'smartos'
   default['tomcat']['log_dir'] = '/opt/local/share/tomcat/logs'
   default['tomcat']['tmp_dir'] = '/opt/local/share/tomcat/temp'
   default['tomcat']['work_dir'] = '/opt/local/share/tomcat/work'
-  default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
+  default['tomcat']['context_dir'] = lazy {"#{node["tomcat"]["config_dir"]}/Catalina/localhost"}
   default['tomcat']['webapp_dir'] = '/opt/local/share/tomcat/webapps'
   default['tomcat']['keytool'] = '/opt/local/bin/keytool'
-  default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["home"]}/lib/endorsed"
+  default['tomcat']['lib_dir'] = lazy {"#{node["tomcat"]["home"]}/lib"}
+  default['tomcat']['endorsed_dir'] = lazy {"#{node["tomcat"]["home"]}/lib/endorsed"}
   default['tomcat']['packages'] = ["apache-tomcat"]
   default['tomcat']['deploy_manager_packages'] = []
 else
-  default['tomcat']['user'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['group'] = "tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['home'] = "/usr/share/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['base'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['config_dir'] = "/etc/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['log_dir'] = "/var/log/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['tmp_dir'] = "/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"
-  default['tomcat']['work_dir'] = "/var/cache/tomcat#{node["tomcat"]["base_version"]}"
-  default['tomcat']['context_dir'] = "#{node["tomcat"]["config_dir"]}/Catalina/localhost"
-  default['tomcat']['webapp_dir'] = "/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"
+  default['tomcat']['user'] = lazy {"tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['group'] = lazy {"tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['home'] = lazy {"/usr/share/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['base'] = lazy {"/var/lib/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['config_dir'] = lazy {"/etc/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['log_dir'] = lazy {"/var/log/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['tmp_dir'] = lazy {"/tmp/tomcat#{node["tomcat"]["base_version"]}-tmp"}
+  default['tomcat']['work_dir'] = lazy {"/var/cache/tomcat#{node["tomcat"]["base_version"]}"}
+  default['tomcat']['context_dir'] = lazy {"#{node["tomcat"]["config_dir"]}/Catalina/localhost"}
+  default['tomcat']['webapp_dir'] = lazy {"/var/lib/tomcat#{node["tomcat"]["base_version"]}/webapps"}
   default['tomcat']['keytool'] = 'keytool'
-  default['tomcat']['lib_dir'] = "#{node["tomcat"]["home"]}/lib"
-  default['tomcat']['endorsed_dir'] = "#{node["tomcat"]["lib_dir"]}/endorsed"
+  default['tomcat']['lib_dir'] = lazy {"#{node["tomcat"]["home"]}/lib"}
+  default['tomcat']['endorsed_dir'] = lazy {"#{node["tomcat"]["lib_dir"]}/endorsed"}
 end


### PR DESCRIPTION
Helps with overriding key attributes (e.g. `['tomcat']['base_version']`) in other recipes

Requires Chef 12+ (ruby 2+)