### PR TITLE
Fix broken kitchen tests

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -47,6 +47,7 @@ platforms:
     ssh_key: <%= ENV['GCE_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-10.04
   driver_plugin: digitalocean
@@ -58,6 +59,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-12.04
   driver_plugin: digitalocean
@@ -69,6 +71,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-14.04
   driver_plugin: digitalocean
@@ -80,6 +83,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: smartos-1330
   driver_plugin: joyent

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,14 +11,17 @@ platforms:
 - name: ubuntu-14.04
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-12.04
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-10.04
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: centos-6.5
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site 'https://supermarket.chef.io'
+source "https://supermarket.getchef.com"
 
 metadata
 


### PR DESCRIPTION
Tests were broken: 
- with latest version of Berkshelf,
- after removing the Java recipe, since no JAVA_HOME env var was found. 

I've included the error messages I was getting. Tests should now work! 

Please let me know if you need anything else to merge this in. 