### PR TITLE
Remove JasperListener from server.xml if base_version is less than 8

### DIFF
--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -29,8 +29,10 @@
   <!--
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
   -->
+  <% if node['tomcat']['base_version'].to_i < 8 -%>
   <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
   <Listener className="org.apache.catalina.core.JasperListener" />
+  <% end -%>
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <% if node['tomcat']['base_version'].to_i < 7 -%>


### PR DESCRIPTION
JasperListener has been removed in Tomcat8. Trying to use it in server.xml causes Tomcat not to start. The changes in this PR remove JasperListener from server.xml if the Tomcat 8 or superior was installed.

from [Tomcat 8.0.0 changelog](https://tomcat.apache.org/tomcat-8.0-doc/changelog.html):
>Initialize the JSP runtime in Jasper's initializer to avoid need for a Jasper-specific lifecycle listener. JasperListener has been removed. (jboynes)

