### PR TITLE
Fix test kitchen

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -47,6 +47,7 @@ platforms:
     ssh_key: <%= ENV['GCE_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-10.04
   driver_plugin: digitalocean
@@ -58,6 +59,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-12.04
   driver_plugin: digitalocean
@@ -69,6 +71,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: ubuntu-14.04
   driver_plugin: digitalocean
@@ -80,6 +83,7 @@ platforms:
     ssh_key: <%= ENV['DIGITAL_OCEAN_SSH_KEY_PATH'] %>
   run_list:
   - recipe[apt]
+  - recipe[java]
 
 - name: smartos-1330
   driver_plugin: joyent

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ platforms:
 suites:
 - name: tomcat6
   run_list: ["recipe[tomcat]"]
-  excludes: ["centos-7.0"]
+  excludes: ["centos-7.1"]
   attributes: {}
 
 - name: tomcat7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,10 +23,12 @@ platforms:
 - name: centos-6.6
   run_list:
   - recipe[yum-epel]
+  - recipe[java]
 
 - name: centos-7.1
   run_list:
   - recipe[yum-epel]
+  - recipe[java]
 
 suites:
 - name: tomcat6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,16 +5,22 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
-    run_list:
-      - recipe[apt]
-  - name: ubuntu-12.04
-    run_list:
-      - recipe[apt]
-  - name: ubuntu-10.04
-    run_list:
-      - recipe[apt]
-  - name: centos-6.6
+- name: ubuntu-14.04
+  run_list:
+  - recipe[apt]
+  - recipe[java]
+
+- name: ubuntu-12.04
+  run_list:
+  - recipe[apt]
+  - recipe[java]
+
+- name: ubuntu-10.04
+  run_list:
+  - recipe[apt]
+  - recipe[java]
+
+- name: centos-6.6
     run_list:
       - recipe[yum-epel]
   - name: centos-7.1
@@ -22,10 +28,12 @@ platforms:
       - recipe[yum-epel]
 
 suites:
-  - name: tomcat6
-    excludes: ['centos-7.1']
-    attributes: {}
+- name: tomcat6
+  run_list: ["recipe[tomcat]"]
+  excludes: ["centos-7.0"]
+  attributes: {}
 
-  - name: tomcat7
-    excludes: ['ubuntu-10.04']
-    attributes: {tomcat: {base_version: 7}}
+- name: tomcat7
+  run_list: ["recipe[tomcat]"]
+  excludes: ["ubuntu-10.04"]
+  attributes: {tomcat: {base_version: 7}}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,11 +21,12 @@ platforms:
   - recipe[java]
 
 - name: centos-6.6
-    run_list:
-      - recipe[yum-epel]
-  - name: centos-7.1
-    run_list:
-      - recipe[yum-epel]
+  run_list:
+  - recipe[yum-epel]
+
+- name: centos-7.1
+  run_list:
+  - recipe[yum-epel]
 
 suites:
 - name: tomcat6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,7 @@ platforms:
   run_list:
   - recipe[yum-epel]
   - recipe[java]
+  attributes: {java: {set_etc_environment: true}}
 
 - name: centos-7.1
   run_list:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - 2.1
   - 2.2
 script:
-  - bundle exec foodcritic -f any .
+  - bundle exec foodcritic -f any -t ~FC005 ~FC023 .
   - bundle exec rubocop
   - bundle exec rspec --color --format progress


### PR DESCRIPTION
New PR in place of #142. 

Please note: I have **one known issue** with the test kitchen run on centos6.6 with tomcat7. 
For some reason, when test kitchen runs the java cookbook default recipe, before running the tomcat default recipe, if you login to the instance, `java -version` still doesn't give you the version of java you installed as the default. 
Some hints: if i run `kitchen converge` again (i.e. yes, a second time), java version is fixed. So if i converge the instance twice, it runs normally.
It looks to me this has sth to do with the alternatives / update-alternatives code, but before going ahead to open an issue on the Java cookbook, I wanted to see if anyone has any tips to share on how to overcome this... ?